### PR TITLE
fix: auto-set DevTools preferences on plugin startup

### DIFF
--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -153,6 +153,17 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
 
   log("Starting RDP server on port " + rdpPort);
 
+  // Ensure DevTools preferences are set (required for RDP to work)
+  try {
+    var start = "devtools.debugger.";
+    Services.prefs.setBoolPref(start + "remote-enabled", true);
+    Services.prefs.setBoolPref(start + "prompt-connection", false);
+    Services.prefs.setBoolPref("devtools.chrome.enabled", true);
+    log("DevTools preferences configured");
+  } catch (e) {
+    log("Warning: Could not set DevTools preferences: " + e);
+  }
+
   try {
     // Initialize DevTools stack
     if (!initDevToolsStack()) {


### PR DESCRIPTION
## Summary

The MCP Bridge plugin silently fails to open port 6100 when DevTools preferences are not configured. This PR adds automatic preference setup in `startup()` before initializing the DevTools stack.

### Preferences set:
- `devtools.debugger.remote-enabled` → `true`
- `devtools.debugger.prompt-connection` → `false`
- `devtools.chrome.enabled` → `true`

## Reproduction

Tested on **macOS 15.4 + Zotero 8.0.3** (fresh install, no prior DevTools config):

**Before (plugin installed, Zotero restarted):**
```
$ lsof -i :6100
# (empty — port not listening)

$ zotero_ping
# ✗ Cannot connect to Zotero RDP at 127.0.0.1:6100
# Error: connect ECONNREFUSED 127.0.0.1:6100
```

- Plugin shows `active: true`, `userDisabled: false` in `extensions.json`
- No `[MCP RDP]` log output in Error Console — `dump()` was suppressed since `browser.dom.window.dump.enabled` defaults to `false`

**After adding prefs via `user.js` and restarting Zotero:**
```
$ lsof -i :6100
zotero  15821 kkimj  25u  IPv4 ...  TCP localhost:synchronet-db (LISTEN)

$ zotero_ping
# ✓ Connected to Zotero 8.0.3
#   Platform: Firefox 140
```

## Likely fixes #1

The Windows issue reported in #1 (port listens but no RDP handshake) may have the same root cause — the `prompt-connection` pref defaulting to `true` causes Zotero to show a confirmation dialog on every connection, blocking automated communication.