### PR TITLE
fix(plugin): stop the health check from closing the live RDP listener every 2s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4955,7 +4955,7 @@
       }
     },
     "packages/zotero-plugin-mcp-rdp": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "adm-zip": "^0.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4955,7 +4955,7 @@
       }
     },
     "packages/zotero-plugin-mcp-rdp": {
-      "version": "1.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "adm-zip": "^0.5.10",

--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -263,3 +263,9 @@ function shutdown({ id, version, resourceURI, rootURI }, reason) {
 function uninstall(data, reason) {
   log("uninstall() called");
 }
+
+// No-op window hooks. Zotero 7+ calls these on every plugin and logs a
+// "Plugin ... is missing bootstrap method" warning per window when absent.
+// The RDP server is window-independent, so there is nothing to do here.
+function onMainWindowLoad() {}
+function onMainWindowUnload() {}

--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -106,30 +106,43 @@ var healthCheckInterval = null;
 function probeConnect() {
   return new Promise(function (resolve) {
     var done = false;
+    var transport = null;
     var finish = function (alive) {
       if (done) return;
       done = true;
+      try { if (transport) transport.close(Components.results.NS_OK); } catch (e) {}
       resolve(alive);
     };
     try {
       var sts = Components.classes["@mozilla.org/network/socket-transport-service;1"]
         .getService(Components.interfaces.nsISocketTransportService);
-      var transport = sts.createTransport([], "127.0.0.1", rdpPort, null, null);
-      var timer = setTimeout(function () {
-        try { transport.close(Components.results.NS_ERROR_ABORT); } catch (e) {}
-        finish(false);
-      }, 1500);
-      transport.setEventSink({
-        onTransportStatus: function (t, status) {
-          if (status === Components.interfaces.nsISocketTransport.STATUS_CONNECTED_TO) {
-            clearTimeout(timer);
-            try { transport.close(Components.results.NS_OK); } catch (e) {}
-            finish(true);
-          }
+      transport = sts.createTransport([], "127.0.0.1", rdpPort, null, null);
+      var timer = setTimeout(function () { finish(false); }, 1500);
+      // IMPORTANT: wait for the server's RDP intro packet and only close
+      // AFTER reading it. Closing at TCP-connect time aborts the connection
+      // mid-handshake - the DevTools server's intro write then hits a dying
+      // socket and the LISTENER itself can self-close, i.e. the probe kills
+      // the very listener it is checking (observed as a 10-20s flap cycle).
+      transport.openOutputStream(0, 0, 0);   // kicks off the connect
+      var input = transport.openInputStream(0, 0, 0);
+      input.asyncWait({
+        onInputStreamReady: function (s) {
+          clearTimeout(timer);
+          var alive = false;
+          try {
+            var n = s.available();           // throws if closed/refused
+            if (n > 0) {
+              alive = true;
+              // Drain the intro bytes so the server's write completes.
+              var sis = Components.classes["@mozilla.org/scriptableinputstream;1"]
+                .createInstance(Components.interfaces.nsIScriptableInputStream);
+              sis.init(s);
+              sis.read(n);
+            }
+          } catch (e) { alive = false; }
+          finish(alive);
         }
-      }, Services.tm.currentThread);
-      // Opening a stream kicks off the actual connection attempt.
-      transport.openOutputStream(0, 0, 0);
+      }, 0, 0, Services.tm.currentThread);
     } catch (e) {
       finish(false);
     }

--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -44,8 +44,17 @@ function initDevToolsStack() {
     }
     DevToolsServer.registerAllActors();
     DevToolsServer.allowChromeProcess = true;
+    // CRITICAL: without keepAlive, the DevToolsServer destroys itself - and
+    // its listeners - whenever the LAST client connection closes. With a
+    // non-destructive health check this surfaces as the listener dying
+    // moments after every probe disconnect (when no MCP client holds a
+    // long-lived connection); the original 2s reopen loop was accidentally
+    // masking it by perpetually recreating the listener. Verified by
+    // holding an external connection open: the kill cycle stopped for
+    // exactly as long as the connection was held.
+    DevToolsServer.keepAlive = true;
 
-    log("DevTools stack initialized");
+    log("DevTools stack initialized (keepAlive=true)");
     return true;
   } catch (e) {
     log("Error initializing DevTools stack: " + e);

--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -86,9 +86,66 @@ async function openListener() {
   }
 }
 
-// Simple periodic reopener - tries to open listener every few seconds
-// If listener is already running, the open() will fail harmlessly (port in use)
+// Periodic NON-DESTRUCTIVE health check.
+//
+// The previous implementation called openListener() every 2 seconds, and
+// openListener() unconditionally CLOSES the live listener before reopening -
+// the "fails harmlessly (port in use)" assumption never held because the
+// close frees the port first. Measured effect: the port refused most
+// incoming connections (35/40 in a 10s probe run) and established
+// connections died within a single cycle, so any RDP request in flight lost
+// its reply (MCP clients saw "undefined" results / transient disconnects).
+//
+// Instead, probe the port as a CLIENT: if a TCP connect to 127.0.0.1:port
+// succeeds, the listener is healthy and is left strictly alone; only when
+// the connect fails (refused / timed out) is the listener actually reopened.
+// (A bind-probe would be unreliable: Mozilla server sockets set SO_REUSEADDR,
+// and on Windows that lets a second bind steal a live port.)
 var healthCheckInterval = null;
+
+function probeConnect() {
+  return new Promise(function (resolve) {
+    var done = false;
+    var finish = function (alive) {
+      if (done) return;
+      done = true;
+      resolve(alive);
+    };
+    try {
+      var sts = Components.classes["@mozilla.org/network/socket-transport-service;1"]
+        .getService(Components.interfaces.nsISocketTransportService);
+      var transport = sts.createTransport([], "127.0.0.1", rdpPort, null, null);
+      var timer = setTimeout(function () {
+        try { transport.close(Components.results.NS_ERROR_ABORT); } catch (e) {}
+        finish(false);
+      }, 1500);
+      transport.setEventSink({
+        onTransportStatus: function (t, status) {
+          if (status === Components.interfaces.nsISocketTransport.STATUS_CONNECTED_TO) {
+            clearTimeout(timer);
+            try { transport.close(Components.results.NS_OK); } catch (e) {}
+            finish(true);
+          }
+        }
+      }, Services.tm.currentThread);
+      // Opening a stream kicks off the actual connection attempt.
+      transport.openOutputStream(0, 0, 0);
+    } catch (e) {
+      finish(false);
+    }
+  });
+}
+
+async function checkListener() {
+  if (isShuttingDown) return;
+  if (rdpListener) {
+    var alive = await probeConnect();
+    if (alive || isShuttingDown) return;   // healthy - do NOT touch the listener
+    log("Health check: port " + rdpPort + " not answering - reopening listener");
+  }
+  var ok = await openListener();
+  if (ok) log("Listener (re)opened by health check");
+}
 
 function startHealthCheck() {
   if (healthCheckInterval) return;
@@ -98,18 +155,10 @@ function startHealthCheck() {
       stopHealthCheck();
       return;
     }
+    checkListener().catch(function () {});
+  }, 10000);  // Probe every 10 seconds (read-only when healthy)
 
-    // Simply try to reopen - openListener handles errors gracefully
-    openListener().then(function(success) {
-      if (success) {
-        log("Listener reopened by health check");
-      }
-    }).catch(function() {
-      // Silently ignore - might be already listening
-    });
-  }, 2000);  // Try every 2 seconds
-
-  log("Health check started");
+  log("Health check started (non-destructive connect-probe, 10s)");
 }
 
 function stopHealthCheck() {


### PR DESCRIPTION
Fixes #3.

## Two bugs, one symptom

1. **`DevToolsServer.keepAlive` is never set** (root cause). The DevTools server destroys itself — listeners included — whenever its connection count drops to zero. Any client disconnect with no other client connected kills the bridge. Pinpointed by holding a single external TCP connection open: a 20 s kill/reopen cycle froze for exactly the duration of the hold.
2. **The 2 s "reopen" health check closes the live listener before rebinding** (and was accidentally *masking* bug 1 by perpetually recreating the listener — at the cost of tearing down the socket every 2 seconds). Measured with the stock bootstrap: **35/40 fresh connections refused** over a 10 s window; an established connection with a 6 s-pending reply **killed after ~240 ms**. This is the root cause of the chronic `undefined` results and "Could not find Zotero console actor" errors MCP clients see.

## Changes

- `DevToolsServer.keepAlive = true` in `initDevToolsStack()` — the server survives its last client disconnecting.
- The health check now probes `127.0.0.1:<port>` as a TCP **client** every 10 s and leaves the listener strictly alone while the port answers; only a failed probe (refused / 1.5 s timeout) triggers an actual reopen. The probe **waits for the RDP intro packet, drains it, and closes gracefully** — closing at TCP-connect time can abort the handshake with side effects on the server (see review comments for the history). A connect-probe is used rather than a bind-probe because Mozilla server sockets set `SO_REUSEADDR`, and on Windows a second bind can steal a live port.
- No-op `onMainWindowLoad`/`onMainWindowUnload` hooks, silencing Zotero 7+'s per-window "missing bootstrap method" console warning.

## Validation

Before/after with the harness from #3 (T3 = in-flight survival, T4 = 40-connect availability), same machine/session:

| | stock bootstrap | this branch |
|---|---|---|
| T3 6 s-pending reply | FAIL — killed at ~240 ms | PASS — arrives intact |
| T4 fresh connects | FAIL — 35/40 refused | PASS — 0/40 |

Plus the keepAlive-specific soak: with **zero clients connected** (the previously fatal condition), the listener survived many consecutive probe ticks with the port answering external probes throughout. Without keepAlive, the same setup produced a kill/reopen cycle every 20 s for ~7 hours straight (lifecycle log from a dev build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
