### PR TITLE
fix(rdp): frame outbound packets with UTF-8 byte length, not character count

### DIFF
--- a/packages/mcp-server/src/rdp/client.ts
+++ b/packages/mcp-server/src/rdp/client.ts
@@ -412,8 +412,13 @@ export class RDPClient extends EventEmitter {
       });
 
       // RDP packet format: <length>:<json>
+      // The length prefix is the UTF-8 BYTE length, not the JS character
+      // count: json.length undercounts any non-ASCII payload (e.g. emoji or
+      // accented text inside code strings), which corrupts the stream and
+      // wedges the connection. The receive path (processBuffer) already does
+      // byte-based framing for the same reason.
       const json = JSON.stringify(message);
-      const packet = `${json.length}:${json}`;
+      const packet = `${Buffer.byteLength(json, "utf8")}:${json}`;
 
       this.socket!.write(packet, (err) => {
         if (err) {


### PR DESCRIPTION
Fixes #4.

RDP's `<length>:<json>` prefix is a **byte** count; `json.length` is the UTF-16 character count. Any non-ASCII character in an outbound payload (emoji/accented text inside `evaluateJS` code, etc.) understated the length, truncating the JSON on the receiving side and desynchronizing the stream — the request times out and the connection is wedged afterwards. The receive path (`processBuffer`) already works byte-correct on raw `Buffer`s for exactly this reason; this applies the same rule to the send path.

```ts
const packet = `${Buffer.byteLength(json, "utf8")}:${json}`;
```

## Validation

`evaluateJS('"echo:" + "⭐"')` against a live Zotero: stock times out every run; with this PR it round-trips. Conversely, a branch containing only this fix still reproduces the resend bug from #5 — the two failures are independent.

Note: `npm test` currently exits 1 on unmodified `main` as well ("No test files found"), so no regression signal is available from the suite; `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
