### PR TITLE
fix(rdp): never resend evaluateJS after a connection drop; fail pending requests on close

### DIFF
--- a/packages/mcp-server/src/rdp/client.ts
+++ b/packages/mcp-server/src/rdp/client.ts
@@ -597,13 +597,23 @@ export class RDPClient extends EventEmitter {
         return this.evaluateJS(code, retryCount + 1);
       }
 
-      // Connection errors: full reconnect needed
-      if (isConnectionError && retryCount < maxRetries) {
-        // Exponential backoff based on consecutive failures
-        const backoffMs = Math.min(1000 * Math.pow(2, this.consecutiveFailures - 1), 5000);
-        await this.delay(backoffMs);
-        await this.reconnect();
-        return this.evaluateJS(code, retryCount + 1);
+      // Connection errors: reconnect so the NEXT call works, but DO NOT
+      // resend this code. A connection drop loses the REPLY, not necessarily
+      // the request - the eval may have already executed in Zotero, and a
+      // blind resend runs its side effects twice (e.g. double plugin
+      // installs, duplicated mutations). Surface an honest error and let the
+      // caller verify before retrying.
+      if (isConnectionError) {
+        try {
+          await this.reconnect();
+        } catch {
+          // Reconnect failure is secondary; report the original drop.
+        }
+        throw new Error(
+          "Connection lost while waiting for the evaluateJS result; " +
+            "the code may or may not have executed in Zotero. " +
+            "Verify its effect before re-running (the connection has been re-established)."
+        );
       }
 
       throw error;
@@ -910,6 +920,15 @@ export class RDPClient extends EventEmitter {
     const wasConnected = this.state.connected;
     this.state.connected = false;
     this.socket = null;
+
+    // Fail pending requests immediately - their replies can never arrive on
+    // a closed socket. They previously sat out the full request timeout
+    // (30s by default) before erroring.
+    this.pendingRequests.forEach((req) => {
+      clearTimeout(req.timeout);
+      req.reject(new Error("Connection closed before a reply arrived"));
+    });
+    this.pendingRequests.clear();
 
     if (wasConnected) {
       this.emit("disconnected");


### PR DESCRIPTION
Fixes #5.

Two related reply-loss problems:

1. **No more blind resend.** `evaluateJS` retried the same code after connection errors. A drop loses the *reply*, not necessarily the request — the eval may already have executed in Zotero, so the resend ran side effects twice (issue #5's repro ends with `count:2` while the call reports success — a silent double execution; think `zotero_plugin_install` running twice). Now the client reconnects so the *next* call works, but rejects this one with an explicit *"the code may or may not have executed in Zotero — verify its effect before re-running"*. Pre-send retries (not-connected / failed proactive health check) are untouched: nothing was transmitted yet, so they remain safe. Actor-error retries are also untouched — "No such actor" means the request was never dispatched to a live actor.

2. **Fast failure on socket close.** `handleClose()` now rejects pending requests immediately ("Connection closed before a reply arrived") instead of letting them sit out the full 30 s request timeout for replies that can never arrive.

## Validation

Issue #5's repro (eval increments a counter, replies after 400 ms, connection killed in between):

| | stock | this PR |
|---|---|---|
| execution count | **2** | **1** |
| caller sees | success | honest "verify before re-running" error |

A branch containing only this fix still reproduces the UTF-8 framing bug from #4 — the two failures are independent. `npm run typecheck` passes (`npm test` exits "No test files found" on unmodified `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
