### PR TITLE
fix(plugin): start the health check even when the boot-time listener open fails

### DIFF
--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -245,18 +245,27 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
     // Open the listener
     var success = await openListener();
     if (success) {
-      rdpStarted = true;
-      startHealthCheck();
       log("SUCCESS - Server listening on port " + rdpPort);
     } else {
       log("Failed to open listener");
     }
+    // Start the health check UNCONDITIONALLY. The non-destructive check
+    // reopens the listener whenever the port stops answering, so a failed
+    // open at startup (e.g. the port was briefly busy by another process or
+    // a not-yet-released previous instance) self-heals on a later tick
+    // instead of leaving the bridge permanently dead until a manual plugin
+    // reload or Zotero restart. Previously this ran only inside the success
+    // branch, so a failed boot-open could never recover.
+    rdpStarted = true;
+    startHealthCheck();
   } catch (e) {
     log("ERROR: " + e);
     if (e.stack) log("Stack: " + e.stack);
     try {
       Zotero.logError(e);
     } catch (e2) {}
+    // Even after an unexpected startup error, keep trying to come up.
+    try { rdpStarted = true; startHealthCheck(); } catch (e3) {}
   }
 }
 


### PR DESCRIPTION
## Problem

`startHealthCheck()` is called only inside the `if (success)` branch of
`startup()` (after `openListener()` succeeds). If the listener **fails to open
at startup** — e.g. port 6100 is briefly held by another process, or by a
previous Zotero/plugin instance that hasn't fully released it — the recovery
health check is never started. The bridge then stays dead until a manual
plugin reload or a full Zotero restart; the otherwise-excellent
non-destructive health check (which would reopen the listener once the port
frees) simply never runs.

This is the one recovery path the recent resilience work (keepAlive,
non-destructive probe) doesn't cover: those handle a listener that dies
*after* a successful start, but not a start that fails outright.

## Fix

Start the health check **unconditionally** after the open attempt (and again
in the `catch`, so even an unexpected startup error still leaves recovery
armed). The probe is read-only when the port is healthy, so always-on costs
nothing in the normal case; when the boot-open failed, it reopens the
listener on a later tick once the port is free.

```diff
   var success = await openListener();
   if (success) {
-    rdpStarted = true;
-    startHealthCheck();
     log("SUCCESS - Server listening on port " + rdpPort);
   } else {
     log("Failed to open listener");
   }
+  rdpStarted = true;
+  startHealthCheck();
 } catch (e) {
   ...
+  try { rdpStarted = true; startHealthCheck(); } catch (e3) {}
 }
```

## Verification

A deterministic harness runs the **real** `startup()` / `checkListener()` /
`startHealthCheck()` text extracted from the bootstrap, with `openListener()`
stubbed, so it tests the actual code path (no mocks of the logic itself):

| Test | before (current `main`) | after (this PR) |
|---|---|---|
| T1 sanity — boot-open **succeeds** | health check starts | health check starts *(identical — harness is fair)* |
| T2 core — boot-open **fails** (port busy) | **not started** → stuck dead | **started** |
| T3 recovery sim — drive the real health-check loop, port frees on tick 3 | — | listener progression `[down, down, UP, up, up]` → self-heals |

Observed in practice on Zotero 10 beta: an instance whose boot-open lost a
port race stayed permanently unreachable until the plugin was toggled by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
