### PR TITLE
docs: fix workspace script examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,14 +302,14 @@ npm install
 npm run build
 
 # Build individual packages
-npm run build -w mcp-server
-npm run build -w zotero-plugin-mcp-rdp
+npm run build:server
+npm run build:plugin
 
 # Run tests
 npm test
 
 # Development mode (watch)
-npm run dev -w mcp-server
+npm run dev
 ```
 
 <details>


### PR DESCRIPTION
## Summary
- replace README workspace command examples with the root scripts already defined in package.json
- avoid using the non-existent short workspace name `mcp-server` in development instructions

## Verification
- `npm.cmd pkg get scripts.build:server scripts.build:plugin scripts.dev`
- `git diff --check`