### PR TITLE
fix(plugin): bump strict_max_version to 10.* for Zotero 10

### DIFF
--- a/packages/zotero-plugin-mcp-rdp/addon/manifest.json
+++ b/packages/zotero-plugin-mcp-rdp/addon/manifest.json
@@ -14,7 +14,7 @@
       "id": "mcp-rdp@zotero.org",
       "update_url": "https://raw.githubusercontent.com/introfini/mcp-server-zotero-dev/main/update.json",
       "strict_min_version": "6.999",
-      "strict_max_version": "9.*"
+      "strict_max_version": "10.*"
     }
   }
 }


### PR DESCRIPTION
The plugin manifest caps `strict_max_version` at `9.*`.

Zotero enforces `strict_max_version` on **stable** builds (`strictCompatibility = true`); only **beta/dev/source** builds skip the check (it is patched off in `app/scripts/fetch_xulrunner`). So on **stable Zotero 10** the plugin is treated as incompatible and disabled — it only keeps working there if the user happens to run a beta build.

This bumps the cap to `10.*`, reflecting validation on Zotero 10.

Suggested convention going forward: raise to `11.*` only after validating on the Zotero 11 beta, before 11 ships stable. The beta ignores `strict_max_version`, so a new major can always be tested there without prematurely claiming compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
