### PR TITLE
fix(tools): wrap open_preferences eval in an IIFE

### DIFF
--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -850,8 +850,8 @@ export async function handleOpenPreferences(
 
   // Build the code to open preferences
   const code = paneId
-    ? `Zotero.Utilities.Internal.openPreferences(${JSON.stringify(paneId)}); return 'Preferences opened to: ${paneId}';`
-    : `Zotero.Utilities.Internal.openPreferences(); return 'Preferences window opened';`;
+    ? `(function(){ Zotero.Utilities.Internal.openPreferences(${JSON.stringify(paneId)}); return 'Preferences opened to: ${paneId}'; })()`
+    : `(function(){ Zotero.Utilities.Internal.openPreferences(); return 'Preferences window opened'; })()`;
 
   const response = await client.evaluateJS(code);
 


### PR DESCRIPTION
`zotero_open_preferences` builds a code string that ends in a top-level `return`:

    Zotero.Utilities.Internal.openPreferences(...); return 'Preferences opened to: ...';

The RDP `evaluateJS` path does not auto-wrap this the way `zotero_execute_js` does, so the eval throws **`SyntaxError: return not in function`** and the tool fails every time.

Wrapping the generated snippet in an IIFE keeps the `return` legal:

    (function(){ Zotero.Utilities.Internal.openPreferences(...); return 'Preferences opened to: ...'; })()

Verified end-to-end on Zotero 10.0-beta.7 — `zotero_open_preferences` now opens the pane with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
