### PR TITLE
fix(tools): handle array return from getConsoleViewerOutput in read_logs

### DIFF
--- a/packages/mcp-server/src/tools/logs.ts
+++ b/packages/mcp-server/src/tools/logs.ts
@@ -118,10 +118,11 @@ export async function handleReadLogs(
         // Try multiple methods to get debug output (Zotero API varies by version)
         let output = '';
 
-        // Method 1: getConsoleViewerOutput (Zotero 7+)
+        // Method 1: getConsoleViewerOutput (Zotero 7+) — returns an ARRAY in current Zotero
         if (!output && typeof Zotero.Debug.getConsoleViewerOutput === 'function') {
           try {
-            output = Zotero.Debug.getConsoleViewerOutput() || '';
+            const cvo = Zotero.Debug.getConsoleViewerOutput();
+            output = Array.isArray(cvo) ? cvo.join('\\n') : (cvo || '');
           } catch (e) {}
         }
 
@@ -152,8 +153,9 @@ export async function handleReadLogs(
           });
         }
 
-        // Parse and filter logs
-        let logLines = output.split('\\n').filter(line => line.trim());
+        // Parse and filter logs (coerce to text in case a method returned a non-string array)
+        const outputText = Array.isArray(output) ? output.join('\\n') : String(output || '');
+        let logLines = outputText.split('\\n').filter(line => line.trim());
 
         // Filter by content
         ${


### PR DESCRIPTION
`zotero_read_logs` fails with `output.split is not a function` on **every** call.

## Root cause
`Zotero.Debug.getConsoleViewerOutput()` returns an **array** in current Zotero (verified on 10.0-beta.7 — it returns `array[N]` of log lines, e.g. `array[3]`). But `src/tools/logs.ts` (Method 1) assigns it straight to `output` assuming a string:

```js
output = Zotero.Debug.getConsoleViewerOutput() || '';   // -> output is an ARRAY
...
let logLines = output.split('\n')...                     // arrays have no .split() -> throws
```

It also failed with **zero** logs: an empty array `[]` is truthy, so `getConsoleViewerOutput() || ''` returns `[]` (not `''`), and the `!output` fallbacks (Methods 2-4) and the "no output captured yet" guard were all skipped. So it threw on every call regardless of log content.

## Fix
Normalize the array to text where it is read (Method 1) — mirroring what Method 3 already does with `_console.join('\n')` — plus a defensive coercion before the split in case `.get()` (Method 2) also returns an array.

## Verified end-to-end on Zotero 10.0-beta.7
- array buffer + filter -> returns the matching lines
- no filter -> returns recent log lines
- level=error on non-error lines -> clean "No logs found" (no crash)

(Worth checking `zotero_read_errors` for the same `getConsoleViewerOutput()` assumption.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
