### PR TITLE
fix(plugin): read the RDP port pref in the file the build actually ships

### DIFF
--- a/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
+++ b/packages/zotero-plugin-mcp-rdp/src/bootstrap.js
@@ -216,9 +216,22 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
     }
   } catch (e) {}
 
-  // Get port (default 6100)
+  // Get port (default 6100).
+  //
+  // The documented name is `extensions.mcp-rdp.port`, which needs the global
+  // flag -- without it Zotero.Prefs resolves the name under `extensions.zotero.`.
+  // 1.0.4 fixed that in src/bootstrap.ts + src/index.ts, but scripts/build.mjs
+  // ships THIS file verbatim, so the released plugin never got the fix.
+  //
+  // Read BOTH, documented name first: every profile configured against the
+  // released builds has its port stored at the `extensions.zotero.`-prefixed
+  // name, and reading only the documented one would silently send those
+  // instances back to the default 6100.
   try {
-    var prefPort = Zotero.Prefs.get("extensions.mcp-rdp.port");
+    var prefPort = Zotero.Prefs.get("extensions.mcp-rdp.port", true);
+    if (!prefPort) {
+      try { prefPort = Zotero.Prefs.get("extensions.mcp-rdp.port"); } catch (e2) {}
+    }
     if (prefPort) rdpPort = prefPort;
   } catch (e) {}
 


### PR DESCRIPTION
## The 1.0.4 port fix didn't reach the shipped plugin

`plugin-v1.0.4`'s release notes say:

> `extensions.mcp-rdp.port` and `extensions.mcp-rdp.enabled` are now actually read: `Zotero.Prefs.get()` calls were missing the global flag

That change is real in `src/bootstrap.ts` and `src/index.ts` — but `scripts/build.mjs` builds the XPI from **`src/bootstrap.js`**:

```js
// scripts/build.mjs
copyFileSync(join(srcDir, "bootstrap.js"), join(buildDir, "bootstrap.js"));
```

and that file is unchanged, so the released 1.0.4 artifact still contains:

```js
var prefPort = Zotero.Prefs.get("extensions.mcp-rdp.port");   // no global flag
```

Without the flag the name resolves under `extensions.zotero.`, so the **documented** pref `extensions.mcp-rdp.port` does nothing and the port really lives at `extensions.zotero.extensions.mcp-rdp.port`. (`enabled` does have the flag in the shipped file; only `port` is affected.)

## Verified end-to-end

Four runs, each a fresh Zotero profile and a fresh empty data dir, same binary (Zotero 10.0-beta.22), differing only in the build and which pref **name** is set:

| build | pref set | listener opens |
|---|---|---|
| official 1.0.4 | `extensions.mcp-rdp.port` = 6177 (documented) | **no** |
| official 1.0.4 | `extensions.zotero.extensions.mcp-rdp.port` = 6178 (legacy) | yes |
| patched | `extensions.mcp-rdp.port` = 6177 | yes |
| patched | `extensions.zotero.extensions.mcp-rdp.port` = 6178 | yes |

Row 2 is the control: same build, same everything, only the pref name differs — so the plugin starts fine and the documented name is simply inert.

## Why this reads both names

A one-sided fix (documented name only) would be a silent regression for anyone already running a custom port: their value is stored at the `extensions.zotero.`-prefixed name, because that's the only thing released builds have ever read. On upgrade they'd fall back to the default 6100 and — for multi-instance setups — collide with another Zotero. I hit exactly this locally with two instances on 6101 and 6102.

So: try the documented name first, fall back to the legacy one. Correct going forward, no migration needed, and the fallback can be dropped after a deprecation period.

Happy to add the same fallback to `src/bootstrap.ts` / `src/index.ts` for consistency, or to split the `.js`/`.ts` duplication question into a separate issue — those two files having drifted is arguably the root cause here.
